### PR TITLE
Access-Control-Allow-Credentials only if true

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,8 +119,6 @@ impl <'r, R: Responder<'r>> Responder<'r> for CORS<R> {
 
         if self.allow_credentials {
             response.set_raw_header("Access-Control-Allow-Credentials", "true");
-        } else {
-            response.set_raw_header("Access-Control-Allow-Credentials", "false");
         }
 
         if !self.expose_headers.is_empty() {


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials

And even that maybe not enough for allow credentials to work:

> However, this header alone is not enough to send cookies to the server. The client code must also set the withCredentials property on the XMLHttpRequest to true in order to give permission.

http://stackoverflow.com/questions/24687313/what-exactly-does-the-access-control-allow-credentials-header-do/24689738#24689738